### PR TITLE
Update to react 0.14 / 15, fix example memory leak

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -24,14 +24,20 @@ class Example extends React.Component {
       progress: 0
     };
     this.onChange = this.onChange.bind(this);
+  }
 
+  componentDidMount() {
     const loop = (t) => {
-      raf(loop);
+      this._loopId = raf(loop);
       this.setState({
         progress: (t/2000) % 1
       });
     };
-    raf(loop);
+    this._loopId = raf(loop);
+  }
+
+  componentWillUnmount() {
+    raf.cancel(this._loopId);
   }
 
   onChange(value) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Cubic Bezier Curve editor made with React & SVG",
   "main": "src/index.js",
   "peerDependencies": {
-    "react": ">=0.12.0 <0.14.0"
+    "react": ">=0.12.0"
   },
   "browserify": {
     "transform": [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Cubic Bezier Curve editor made with React & SVG",
   "main": "src/index.js",
   "peerDependencies": {
-    "react": "^0.14 || ^15.0"
+    "react": "^0.14 || ^15.0",
+    "react-dom": "^0.14 || ^15.0"
   },
   "browserify": {
     "transform": [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Cubic Bezier Curve editor made with React & SVG",
   "main": "src/index.js",
   "peerDependencies": {
-    "react": ">=0.12.0"
+    "react": "^0.14 || ^15.0"
   },
   "browserify": {
     "transform": [

--- a/src/BezierEditor.js
+++ b/src/BezierEditor.js
@@ -1,4 +1,5 @@
 import React from "react";
+import {findDOMNode} from "react-dom";
 import objectAssign from "object-assign";
 const {PropTypes, Component} = React;
 
@@ -205,7 +206,7 @@ export default class BezierEditor extends Component {
   }
 
   positionForEvent (e) {
-    const rect = React.findDOMNode(this).getBoundingClientRect();
+    const rect = findDOMNode(this).getBoundingClientRect();
     return [
       e.clientX - rect.left,
       e.clientY - rect.top


### PR DESCRIPTION
Closes #5 
Closes #6: It works with React 0.14 out-of-the-box, though you get a warning related to the use of `React.findDOMNode` in `BezierEditor.js:208`. Importing findDOMNode from react-dom, instead of react, removes the warning and makes it fully compatible with React 15.x. Note, however, that this breaks backwards-compatibility with React 0.13.x.
