### PR TITLE
Fix example crash on GitHub Pages (duplicate React in bundle)

### DIFF
--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -5,4 +5,10 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   base: "/bezier-easing-editor/",
   plugins: [react()],
+  resolve: {
+    // bezier-easing-editor is symlinked (file:..), so its "react" import
+    // resolves to the parent repo's node_modules: dedupe to avoid bundling
+    // two React copies (hooks crash with a null dispatcher otherwise)
+    dedupe: ["react", "react-dom"],
+  },
 });


### PR DESCRIPTION
The deployed example crashed with `Cannot read properties of null (reading 'useState')`.

## Root cause

The example depends on the library via `file:..`, which npm installs as a **symlink**. When Vite resolves the library's `import "react"` from the real path (`../dist/index.js`), it lands on the parent repo's `node_modules/react` (a devDependency of the library), while the app code uses `example/node_modules/react`. Both copies of React core got bundled — confirmed by logging `moduleParsed` ids during the build:

```
REACT MODULE: /example/node_modules/react/cjs/react.production.js
REACT MODULE: /node_modules/react/cjs/react.production.js   ← duplicate
```

The library's components ran against the copy that react-dom never wires up, so the hooks dispatcher was null.

## Fix

`resolve.dedupe: ["react", "react-dom"]` in the example's Vite config — the standard fix for symlinked packages. The duplicate is gone from the bundle (−1.6 kB).

## Verification

Rendered the built output in headless Chrome (`--dump-dom`): all 5 editors render with their handles (previously the page was blank). Merging will redeploy Pages automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)