### PR TITLE
Improve touch support: enlarged handle hit areas, scoped touch-action

### DIFF
--- a/.changeset/touch-support.md
+++ b/.changeset/touch-support.md
@@ -2,4 +2,8 @@
 "bezier-easing-editor": minor
 ---
 
-Improve touch support: handles now have a larger invisible hit area (min 44px diameter) so they are easy to grab with a finger, and `touch-action: none` is scoped to the handles instead of the whole editor so the page can still be scrolled from the editor background.
+Improve touch support:
+
+- handles now have a larger invisible hit area (min 44px diameter) so they are easy to grab with a finger
+- multi-touch: each handle can be dragged by a different finger simultaneously
+- touches starting on a handle no longer scroll the page (works on iOS Safari where `touch-action` is ignored on SVG children), while the page can still be scrolled from the editor background

--- a/.changeset/touch-support.md
+++ b/.changeset/touch-support.md
@@ -1,0 +1,5 @@
+---
+"bezier-easing-editor": minor
+---
+
+Improve touch support: handles now have a larger invisible hit area (min 44px diameter) so they are easy to grab with a finger, and `touch-action: none` is scoped to the handles instead of the whole editor so the page can still be scrolled from the editor background.

--- a/src/BezierEditor.test.tsx
+++ b/src/BezierEditor.test.tsx
@@ -6,7 +6,9 @@ import type { BezierValue } from "./index";
 afterEach(cleanup);
 
 function getHandles(container: HTMLElement) {
-  return Array.from(container.querySelectorAll("circle"));
+  return Array.from(
+    container.querySelectorAll<SVGCircleElement>("circle[data-handle]")
+  );
 }
 
 // jsdom has no real PointerEvent: fireEvent.pointerMove drops clientX/clientY.
@@ -119,6 +121,30 @@ describe("BezierEditor", () => {
     pointerUp();
     expect(onChange).toHaveBeenCalled();
     expect(curveD()).not.toBe(before);
+  });
+
+  it("supports touch: drags via touch pointer events on the enlarged hit area", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <BezierEditor value={[0.25, 0.25, 0.75, 0.75]} onChange={onChange} />
+    );
+    const [handle1] = getHandles(container);
+    // the invisible hit area must be comfortably larger than the visible handle
+    expect(Number(handle1.getAttribute("r"))).toBeGreaterThanOrEqual(22);
+    expect(handle1.style.touchAction).toBe("none");
+    fireEvent.pointerDown(handle1, { pointerType: "touch" });
+    fireEvent(
+      window,
+      new MouseEvent("pointermove", { clientX: 120, clientY: 80 })
+    );
+    expect(onChange).toHaveBeenCalledTimes(1);
+    fireEvent(window, new MouseEvent("pointercancel"));
+    onChange.mockClear();
+    fireEvent(
+      window,
+      new MouseEvent("pointermove", { clientX: 140, clientY: 90 })
+    );
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it("does not respond to pointer events in readOnly mode", () => {

--- a/src/BezierEditor.test.tsx
+++ b/src/BezierEditor.test.tsx
@@ -11,13 +11,24 @@ function getHandles(container: HTMLElement) {
   );
 }
 
-// jsdom has no real PointerEvent: fireEvent.pointerMove drops clientX/clientY.
-// Dispatch MouseEvent-backed events with pointer event types instead.
-function pointerMove(clientX: number, clientY: number) {
-  fireEvent(window, new MouseEvent("pointermove", { clientX, clientY }));
+// jsdom has no real PointerEvent: back pointer events with MouseEvent and
+// attach an explicit pointerId
+function pointerEvent(type: string, pointerId: number, init: MouseEventInit = {}) {
+  const e = new MouseEvent(type, { bubbles: true, cancelable: true, ...init });
+  Object.defineProperty(e, "pointerId", { value: pointerId });
+  return e;
 }
-function pointerUp() {
-  fireEvent(window, new MouseEvent("pointerup"));
+function pointerDown(el: Element, pointerId = 1) {
+  fireEvent(el, pointerEvent("pointerdown", pointerId));
+}
+function pointerMove(clientX: number, clientY: number, pointerId = 1) {
+  fireEvent(window, pointerEvent("pointermove", pointerId, { clientX, clientY }));
+}
+function pointerUp(pointerId = 1) {
+  fireEvent(window, pointerEvent("pointerup", pointerId));
+}
+function pointerCancel(pointerId = 1) {
+  fireEvent(window, pointerEvent("pointercancel", pointerId));
 }
 
 describe("BezierEditor", () => {
@@ -47,7 +58,6 @@ describe("BezierEditor", () => {
     const paths = Array.from(container.querySelectorAll("path"));
     const curve = paths.find((p) => p.getAttribute("d")?.includes("C"));
     expect(curve).toBeDefined();
-    // x1=0 maps to left edge (padding-left = 18), y1=1 maps to top (padding-top = 25)
     expect(curve!.getAttribute("d")).toContain("C18,25");
   });
 
@@ -75,18 +85,15 @@ describe("BezierEditor", () => {
       <BezierEditor value={value} onChange={onChange} />
     );
     const [handle1] = getHandles(container);
-    fireEvent.pointerDown(handle1);
+    pointerDown(handle1);
     pointerMove(100, 100);
     expect(onChange).toHaveBeenCalledTimes(1);
     const next = onChange.mock.calls[0][0] as BezierValue;
     expect(next).toHaveLength(4);
-    // only the first control point moved
     expect(next[2]).toBe(0.75);
     expect(next[3]).toBe(0.75);
-    // x is clamped to [0,1]
     expect(next[0]).toBeGreaterThanOrEqual(0);
     expect(next[0]).toBeLessThanOrEqual(1);
-    // original value is not mutated
     expect(value).toEqual([0.25, 0.25, 0.75, 0.75]);
     pointerUp();
   });
@@ -97,7 +104,7 @@ describe("BezierEditor", () => {
       <BezierEditor value={[0.25, 0.25, 0.75, 0.75]} onChange={onChange} />
     );
     const [, handle2] = getHandles(container);
-    fireEvent.pointerDown(handle2);
+    pointerDown(handle2);
     pointerMove(50, 50);
     pointerUp();
     onChange.mockClear();
@@ -116,7 +123,7 @@ describe("BezierEditor", () => {
         .getAttribute("d");
     const before = curveD();
     const [handle1] = getHandles(container);
-    fireEvent.pointerDown(handle1);
+    pointerDown(handle1);
     pointerMove(200, 200);
     pointerUp();
     expect(onChange).toHaveBeenCalled();
@@ -129,22 +136,64 @@ describe("BezierEditor", () => {
       <BezierEditor value={[0.25, 0.25, 0.75, 0.75]} onChange={onChange} />
     );
     const [handle1] = getHandles(container);
-    // the invisible hit area must be comfortably larger than the visible handle
     expect(Number(handle1.getAttribute("r"))).toBeGreaterThanOrEqual(22);
     expect(handle1.style.touchAction).toBe("none");
-    fireEvent.pointerDown(handle1, { pointerType: "touch" });
-    fireEvent(
-      window,
-      new MouseEvent("pointermove", { clientX: 120, clientY: 80 })
-    );
+    // touches starting on the handle must not scroll the page: the native
+    // non-passive touchstart listener prevents the default action
+    const touchStart = new Event("touchstart", {
+      bubbles: true,
+      cancelable: true,
+    });
+    handle1.dispatchEvent(touchStart);
+    expect(touchStart.defaultPrevented).toBe(true);
+    pointerDown(handle1);
+    pointerMove(120, 80);
     expect(onChange).toHaveBeenCalledTimes(1);
-    fireEvent(window, new MouseEvent("pointercancel"));
+    pointerCancel();
     onChange.mockClear();
-    fireEvent(
-      window,
-      new MouseEvent("pointermove", { clientX: 140, clientY: 90 })
-    );
+    pointerMove(140, 90);
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("supports multi-touch: two fingers drag the two handles simultaneously", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <BezierEditor
+        defaultValue={[0.25, 0.25, 0.75, 0.75]}
+        onChange={onChange}
+      />
+    );
+    const [handle1, handle2] = getHandles(container);
+    pointerDown(handle1, 1);
+    pointerDown(handle2, 2);
+    pointerMove(60, 250, 1);
+    pointerMove(250, 60, 2);
+    const last = onChange.mock.calls.at(-1)![0] as BezierValue;
+    expect(last[0]).not.toBe(0.25);
+    expect(last[2]).not.toBe(0.75);
+    pointerUp(1);
+    onChange.mockClear();
+    pointerMove(80, 220, 1);
+    expect(onChange).not.toHaveBeenCalled();
+    pointerMove(240, 70, 2);
+    expect(onChange).toHaveBeenCalled();
+    pointerUp(2);
+  });
+
+  it("ignores a second pointer grabbing an already-dragged handle", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <BezierEditor value={[0.25, 0.25, 0.75, 0.75]} onChange={onChange} />
+    );
+    const [handle1] = getHandles(container);
+    pointerDown(handle1, 1);
+    pointerDown(handle1, 2);
+    pointerMove(100, 100, 2);
+    expect(onChange).not.toHaveBeenCalled();
+    pointerMove(100, 100, 1);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    pointerUp(1);
+    pointerUp(2);
   });
 
   it("does not respond to pointer events in readOnly mode", () => {

--- a/src/BezierEditor.tsx
+++ b/src/BezierEditor.tsx
@@ -84,20 +84,29 @@ export default function BezierEditor({
   const isControlled = controlledValue !== undefined;
   const value = isControlled ? controlledValue : uncontrolledValue;
 
-  const [down, setDown] = useState<0 | 1 | 2>(0);
   const [hover, setHover] = useState<0 | 1 | 2>(0);
+  const [dragVersion, setDragVersion] = useState(0);
   const rootRef = useRef<SVGSVGElement>(null);
+  const dragsRef = useRef(new Map<number, 1 | 2>());
 
-  // Latest state for the window pointermove handler, so the drag effect
-  // doesn't need to re-subscribe on every value change.
-  const latest = useRef({ value, padding, width, height, handleRadius, onChange, isControlled });
-  latest.current = { value, padding, width, height, handleRadius, onChange, isControlled };
+  // refs so the window listeners always see the latest props, and so two
+  // pointermove events in the same frame don't overwrite each other's change
+  const latest = useRef({ padding, width, height, handleRadius, onChange, isControlled });
+  latest.current = { padding, width, height, handleRadius, onChange, isControlled };
+  const valueRef = useRef(value);
+  valueRef.current = value;
+
+  const down1 = [...dragsRef.current.values()].includes(1);
+  const down2 = [...dragsRef.current.values()].includes(2);
+  const anyDown = down1 || down2;
 
   useEffect(() => {
-    if (!down) return;
+    if (!anyDown) return;
     const onPointerMove = (e: PointerEvent) => {
+      const handle = dragsRef.current.get(e.pointerId);
+      if (!handle) return;
       e.preventDefault();
-      const { value, padding, width, height, handleRadius, onChange, isControlled } =
+      const { padding, width, height, handleRadius, onChange, isControlled } =
         latest.current;
       const rect = rootRef.current?.getBoundingClientRect();
       if (!rect) return;
@@ -112,34 +121,45 @@ export default function BezierEditor({
       const cy = Math.max(clampMargin, Math.min(py, height - clampMargin));
       const yval = 1 - (cy - padding[0]) / h;
 
-      const next = value.slice() as BezierValue;
-      const i = 2 * (down - 1);
+      const next = valueRef.current.slice() as BezierValue;
+      const i = 2 * (handle - 1);
       next[i] = xval;
       next[i + 1] = yval;
+      valueRef.current = next;
       if (!isControlled) setUncontrolledValue(next);
       onChange?.(next);
     };
-    const onPointerUp = () => setDown(0);
+    const onPointerEnd = (e: PointerEvent) => {
+      if (dragsRef.current.delete(e.pointerId)) {
+        setDragVersion((v) => v + 1);
+      }
+    };
     window.addEventListener("pointermove", onPointerMove);
-    window.addEventListener("pointerup", onPointerUp);
-    window.addEventListener("pointercancel", onPointerUp);
+    window.addEventListener("pointerup", onPointerEnd);
+    window.addEventListener("pointercancel", onPointerEnd);
     return () => {
       window.removeEventListener("pointermove", onPointerMove);
-      window.removeEventListener("pointerup", onPointerUp);
-      window.removeEventListener("pointercancel", onPointerUp);
+      window.removeEventListener("pointerup", onPointerEnd);
+      window.removeEventListener("pointercancel", onPointerEnd);
     };
-  }, [down]);
+  }, [anyDown, dragVersion]);
 
-  const onDownHandle1 = useCallback((e: React.PointerEvent) => {
+  const beginDrag = useCallback((handle: 1 | 2, e: React.PointerEvent) => {
     e.preventDefault();
+    const drags = dragsRef.current;
+    if ([...drags.values()].includes(handle)) return;
+    drags.set(e.pointerId, handle);
     setHover(0);
-    setDown(1);
+    setDragVersion((v) => v + 1);
   }, []);
-  const onDownHandle2 = useCallback((e: React.PointerEvent) => {
-    e.preventDefault();
-    setHover(0);
-    setDown(2);
-  }, []);
+  const onDownHandle1 = useCallback(
+    (e: React.PointerEvent) => beginDrag(1, e),
+    [beginDrag]
+  );
+  const onDownHandle2 = useCallback(
+    (e: React.PointerEvent) => beginDrag(2, e),
+    [beginDrag]
+  );
   const onEnterHandle1 = useCallback(() => setHover((h) => h || 1), []);
   const onEnterHandle2 = useCallback(() => setHover((h) => h || 2), []);
   const onLeaveHandle = useCallback(() => setHover(0), []);
@@ -164,26 +184,27 @@ export default function BezierEditor({
 
   const styles: CSSProperties = {
     background,
-    cursor: down ? cursor.down : hover ? cursor.hover : cursor.def,
+    cursor: anyDown ? cursor.down : hover ? cursor.hover : cursor.def,
     userSelect: "none",
     ...style,
   };
 
-  const interactive = !readOnly && !down;
-  const handle1Events = interactive
-    ? {
-        onPointerDown: onDownHandle1,
-        onPointerEnter: onEnterHandle1,
-        onPointerLeave: onLeaveHandle,
-      }
-    : {};
-  const handle2Events = interactive
-    ? {
-        onPointerDown: onDownHandle2,
-        onPointerEnter: onEnterHandle2,
-        onPointerLeave: onLeaveHandle,
-      }
-    : {};
+  const handle1Events =
+    readOnly || down1
+      ? {}
+      : {
+          onPointerDown: onDownHandle1,
+          onPointerEnter: onEnterHandle1,
+          onPointerLeave: onLeaveHandle,
+        };
+  const handle2Events =
+    readOnly || down2
+      ? {}
+      : {
+          onPointerDown: onDownHandle2,
+          onPointerEnter: onEnterHandle2,
+          onPointerLeave: onLeaveHandle,
+        };
 
   return (
     <svg
@@ -224,7 +245,7 @@ export default function BezierEditor({
             handleColor={handleColor}
             handleStroke={handleStroke}
             background={background}
-            down={down === 1}
+            down={down1}
             hover={hover === 1}
           />
           <Handle
@@ -237,7 +258,7 @@ export default function BezierEditor({
             handleColor={handleColor}
             handleStroke={handleStroke}
             background={background}
-            down={down === 2}
+            down={down2}
             hover={hover === 2}
           />
         </g>

--- a/src/BezierEditor.tsx
+++ b/src/BezierEditor.tsx
@@ -166,7 +166,6 @@ export default function BezierEditor({
     background,
     cursor: down ? cursor.down : hover ? cursor.hover : cursor.def,
     userSelect: "none",
-    touchAction: "none",
     ...style,
   };
 

--- a/src/Handle.tsx
+++ b/src/Handle.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useEffect, useRef } from "react";
 import type { PointerEventHandler } from "react";
 import { projectX, projectY, type Projection } from "./types";
 
@@ -33,6 +33,18 @@ function Handle(props: HandleProps) {
     onPointerLeave,
   } = props;
 
+  // touch-action is ignored on SVG children by some browsers (iOS Safari) and
+  // React registers touch listeners as passive: preventing the scroll on
+  // handle touches requires a native non-passive touchstart listener
+  const hitRef = useRef<SVGCircleElement>(null);
+  useEffect(() => {
+    const el = hitRef.current;
+    if (!el) return;
+    const onTouchStart = (e: TouchEvent) => e.preventDefault();
+    el.addEventListener("touchstart", onTouchStart, { passive: false });
+    return () => el.removeEventListener("touchstart", onTouchStart);
+  }, []);
+
   const sx = projectX(props, index);
   const sy = projectY(props, index);
   const cx = projectX(props, xval);
@@ -59,8 +71,8 @@ function Handle(props: HandleProps) {
         strokeWidth={hover || down ? 2 * handleStroke : handleStroke}
         fill={down ? background : handleColor}
       />
-      {/* invisible hit area, larger than the visible handle for touch */}
       <circle
+        ref={hitRef}
         data-handle={index}
         cx={cx}
         cy={cy}

--- a/src/Handle.tsx
+++ b/src/Handle.tsx
@@ -58,6 +58,14 @@ function Handle(props: HandleProps) {
         stroke={handleColor}
         strokeWidth={hover || down ? 2 * handleStroke : handleStroke}
         fill={down ? background : handleColor}
+      />
+      {/* invisible hit area, larger than the visible handle for touch */}
+      <circle
+        data-handle={index}
+        cx={cx}
+        cy={cy}
+        r={Math.max(2 * handleRadius, 22)}
+        fill="transparent"
         style={{ touchAction: "none" }}
         onPointerDown={onPointerDown}
         onPointerEnter={onPointerEnter}

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,10 +9,7 @@ export type BezierValue = [number, number, number, number];
  */
 export type Padding = [number, number, number, number];
 
-/**
- * Pixel-space projection shared by the SVG sub-components.
- * Maps the unit interval to pixel coordinates of the grid corners.
- */
+/** Pixel coordinates of the grid corners, mapping the unit interval. */
 export interface Projection {
   xFrom: number;
   yFrom: number;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     // tsup's dts build injects baseUrl, deprecated in TypeScript 6
     "ignoreDeprecations": "6.0",
-    "target": "ES2020",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "jsx": "react-jsx",


### PR DESCRIPTION
Follow-up on mobile support. The pointer-events rewrite (#17) made touch dragging *work*, but real-finger usage had several issues, all addressed here:

## 1. Handles were ~10px wide
Far below the ~44px touch target guideline. Each handle now has an **invisible hit-area circle** (radius `max(2 × handleRadius, 22)` → min 44px diameter, `data-handle` attribute) that carries the pointer events. The visible circle is purely cosmetic.

## 2. Touching a handle scrolled the page
`touch-action: none` is ignored on **SVG child elements** by some browsers (iOS Safari), and React registers touch listeners as passive. The hit area attaches a **native non-passive `touchstart` listener** that calls `preventDefault()` — drags from a handle never scroll, while the editor background still scrolls the page normally.

## 3. Multi-touch
Drag state went from a single `down` value to a **`pointerId → handle` map**: each handle can be dragged by a different finger at the same time, and releasing one finger doesn't interrupt the other. An optimistic value ref prevents two same-frame pointermove events from overwriting each other's change.

Desktop behavior is unchanged.

## Verification

- Tested on a real phone over the local network (drag, scroll, two-finger drag).
- Two-finger e2e in Chrome touch emulation (puppeteer `TouchHandle` API): both control points move simultaneously, finger 2 keeps dragging after finger 1 lifts, no page errors.
- 13 unit tests, including multi-touch, scroll prevention, and double-grab of the same handle.

Includes a `minor` changeset → merging will open the Version Packages PR for **1.1.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)