### PR TITLE
Redirect legacy /example/ URL to the Pages root (fixes #13)

### DIFF
--- a/example/public/example/index.html
+++ b/example/public/example/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<!-- The example used to be deployed under /example/ (gh-pages branch era).
+     Redirect legacy links to the new root deployment. -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=../" />
+    <link rel="canonical" href="https://gre.github.io/bezier-easing-editor/" />
+    <title>bezier-easing-editor</title>
+  </head>
+  <body>
+    <p>This page has moved to <a href="../">gre.github.io/bezier-easing-editor</a>.</p>
+  </body>
+</html>


### PR DESCRIPTION
Closes #13.

The broken `Source code of these examples.` link reported in the issue was already fixed by the Vite migration (#17): the deployed app now points to [`example/src/App.tsx`](https://github.com/gre/bezier-easing-editor/blob/master/example/src/App.tsx), which exists.

What remained broken is the **legacy URL itself**: the example used to be served at `/bezier-easing-editor/example/` (gh-pages branch era, the URL referenced in the issue), which 404s since the new Pages deployment serves the example at the root. This PR adds a static `example/index.html` (via Vite's `public/` dir) with a meta refresh + canonical link redirecting old links to the root.

Verified on `vite preview`: `/bezier-easing-editor/example/` serves the redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)