### PR TITLE
Update GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -21,9 +21,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -40,7 +40,7 @@ jobs:
           npm run build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: example/dist
 
@@ -53,4 +53,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm


### PR DESCRIPTION
The release run for v1.1.0 flagged `actions/checkout@v4` and `actions/setup-node@v4` as running on the deprecated Node 20 runtime (GitHub forces Node 24 starting June 16th, 2026, and removes Node 20 from runners on September 16th, 2026).

This bumps all first-party actions across the three workflows to their current majors, which run on Node 24:

- `actions/checkout` v4 → v6 (ci, release, deploy-pages)
- `actions/setup-node` v4 → v6 (ci, release, deploy-pages)
- `actions/upload-pages-artifact` v3 → v5 (deploy-pages)
- `actions/deploy-pages` v4 → v5 (deploy-pages)

No workflow inputs changed; `changesets/action@v1` is already on its latest major. No changeset: workflow-only change, nothing published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)